### PR TITLE
Fixed bugs and detail layouts about andorid xml

### DIFF
--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -146,7 +146,7 @@ export class androidDefaultBuilder {
       }
     }
 
-    if (node.type === "COMPONENT" || node.type === "INSTANCE") {
+    if (node.parent?.type !== "FRAME" && (node.type === "COMPONENT" || node.type === "INSTANCE")) {
       if (node.paddingTop > 0) {
         this.pushModifier(["android:layout_marginTop",`${node.paddingTop}dp`]);
       }

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -488,14 +488,13 @@ const createDirectionalStack = (
   node: SceneNode & InferredAutoLayoutResult,
   isClickable: boolean = false
   ): string => {
-    const { x, y } = getCommonPositionValue(node);
     const {height, width} = androidSize(node, localSettings.optimizeLayout);
     const hasLinearLayoutParent = node.parent?.name.split("_")[1] === "linear"
 
     let prop:Record<string, string | number> = {
       "android:id": `@+id/${idName}`,
-      "android:layout_width": `${width}`,
-      "android:layout_height": `${height}`
+      "android:layout_width": `${node.parent ? width : "match_parent"}`,
+      "android:layout_height": `${node.parent ? height : "match_parent"}`
     }
 
     const grandchildrenHaveRadioButton = 
@@ -507,11 +506,14 @@ const createDirectionalStack = (
         node.name.split("_")[1] === "radioButton"
       ).length !== 0
     ).length !== 0
-    
-    if (!hasLinearLayoutParent || ("layoutPositioning" in node && node.layoutPositioning === "ABSOLUTE") ) {
-      prop['android:layout_marginStart']=`${sliceNum(x)}dp`;
-      prop['android:layout_marginTop']=`${sliceNum(y)}dp`;
+
+    if (node.parent && (!hasLinearLayoutParent || ("layoutPositioning" in node && node.layoutPositioning === "ABSOLUTE"))) {
+      prop['android:layout_marginStart']=`${sliceNum(node.x)}dp`;
+      prop['android:layout_marginTop']=`${sliceNum(node.y)}dp`;
+    } if (!node.parent) {
+      prop["xmlns:android"]="http://schemas.android.com/apk/res/android"
     }
+
     if (node.paddingTop > 0) {
       prop["android:paddingTop"] = `${node.paddingTop}dp`
     }

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -180,7 +180,7 @@ const androidText = (node: SceneNode & TextNode, sizeNode: SceneNode | null = nu
   const result = new androidTextBuilder()
     .createText(node)
     .setId(node)
-    .position(node, localSettings.optimizeLayout)
+    .position(sizeNode ? sizeNode : node, localSettings.optimizeLayout)
     .size(sizeNode ? sizeNode : node, localSettings.optimizeLayout);
 
   result.pushModifier(androidShadow(node));
@@ -352,8 +352,13 @@ const androidFrame = (
 const androidComponent = (node: SceneNode & BaseFrameMixin & TextNode, indentLevel: number): string => {
   switch (node.name.split("_")[1]) {
     case "text":
-      if ("children" in node && node.children[0].type === "TEXT") {
-        return androidText(node.children[0], node)
+      if (
+        "children" in node &&
+        node.children[0].type === "FRAME" &&
+        "children" in node.children[0] &&
+        node.children[0].children[0].type === "TEXT"
+      ) {
+        return androidText(node.children[0].children[0], node)
       }
     case "btn":
       return androidButton(node)

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -505,7 +505,7 @@ const createDirectionalStack = (
       && node.name.split("_")[1] === "linear" 
       && node.children.filter(node => 
         node.name.split("_")[1] === "radioButton"
-      )
+      ).length !== 0
     ).length !== 0
     
     if (!hasLinearLayoutParent || ("layoutPositioning" in node && node.layoutPositioning === "ABSOLUTE") ) {


### PR DESCRIPTION
## Did
[Replaced base layout from ConstraintLayout to FrameLayout.](https://github.com/HiroMoriguchi-pioneer/FigmaToCode/commit/2cdea757c63b08b0fad0996cca906c45e067d757)

[Added a frame figma object in text component to receive component pad…](https://github.com/HiroMoriguchi-pioneer/FigmaToCode/commit/f4f69e19724c5da9e0ffb618b973755d1105838c)

[Integrated creationDirectionalStack and creationDirectionalStackScroll.](https://github.com/HiroMoriguchi-pioneer/FigmaToCode/commit/813ce6e4a94117bf290e9f5bf5d54e0f88d706f4)


## Fixed

[Fixed filtering about grand children have radioButton.](https://github.com/HiroMoriguchi-pioneer/FigmaToCode/commit/95377160af9f76560dd52479e8cd1a0ad536d386)