### PR TITLE
Fixed LinearLayout ID and size.

### DIFF
--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -193,7 +193,7 @@ export class androidDefaultBuilder {
   }
 
   spaceSize(node: SceneNode): this {
-    if ((node.parent?.type === "COMPONENT" || node.parent?.type === "INSTANCE") ) {
+    if ((node.parent?.type === "COMPONENT" || node.parent?.type === "INSTANCE" || node.parent?.type === "FRAME") ) {
       if (node.parent.layoutMode === "VERTICAL") {
         this.pushModifier(['android:layout_width', `match_parent`])
         this.pushModifier(['android:layout_height', `${node.parent.itemSpacing}dp`])

--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -182,12 +182,15 @@ export class androidDefaultBuilder {
   }
 
   size(node: SceneNode, optimize: boolean): this {
-    const { width, height } = androidSize(node, optimize);
+    const { width, height, weight} = androidSize(node, optimize);
     if (width) {
       this.pushModifier(['android:layout_width', `${width}`]);
     }
     if (height) {
       this.pushModifier(['android:layout_height', `${height}`]);
+    }
+    if (weight) {
+      this.pushModifier(['android:layout_weight', `1`]);
     }
     return this;
   }

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -61,10 +61,10 @@ const androidWidgetGenerator = (
   visibleSceneNode.forEach((node, index) => {
     const parentType = androidNameParser(node.parent?.name).type
     const isLinearLayout = parentType === AndroidType.linearLayout
-    const isComponentOrInstanceParent = node.parent?.type === "COMPONENT" || node.parent?.type === "INSTANCE"
+    const hasStackParent = node.parent?.type === "COMPONENT" || node.parent?.type === "INSTANCE" || node.parent?.type === "FRAME"
     const isFirstItem = node.parent?.children[0] === node
 
-    if (isLinearLayout && !isFirstItem && isComponentOrInstanceParent && node.parent.itemSpacing !== 0) {
+    if (isLinearLayout && !isFirstItem && hasStackParent && node.parent.itemSpacing !== 0) {
       comp.push(androidLinearSpace(node));
     }
 
@@ -97,6 +97,9 @@ const androidWidgetGenerator = (
         break;
       case "FRAME":
       case "COMPONENT_SET":
+        if (androidNameParser(node.name).type === AndroidType.linearLayout) {
+          comp.push(androidComponent(node, indentLevel))
+        }
         comp.push(androidFrame(node, indentLevel));
         break;
       case "TEXT":

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -471,7 +471,7 @@ const createDirectionalStack = (
   node: SceneNode & InferredAutoLayoutResult,
   isClickable: boolean = false
   ): string => {
-    const {height, width} = androidSize(node, localSettings.optimizeLayout);
+    const {height, width, weight} = androidSize(node, localSettings.optimizeLayout);
     const {type, id}  = androidNameParser(idName)
     const parentType = androidNameParser(node.parent?.name).type
     const hasLinearLayoutParent = parentType === AndroidType.linearLayout
@@ -479,6 +479,10 @@ const createDirectionalStack = (
     let prop:Record<string, string | number> = {
       "android:layout_width": `${node.parent ? width : "match_parent"}`,
       "android:layout_height": `${node.parent ? height : "match_parent"}`
+    }
+
+    if (weight) {
+      prop["android:layout_weight"] = `1` 
     }
 
     if (id !== "") {

--- a/packages/backend/src/android/builderImpl/androidNameParser.ts
+++ b/packages/backend/src/android/builderImpl/androidNameParser.ts
@@ -68,6 +68,8 @@ export const androidNameParser = (name: string | undefined): { type: AndroidType
         break
       case "linear":
       case "lin":
+      case "vLinear":
+      case "hLinear":
         type = AndroidType.linearLayout
         break
       default:

--- a/packages/backend/src/android/builderImpl/androidSize.ts
+++ b/packages/backend/src/android/builderImpl/androidSize.ts
@@ -4,27 +4,49 @@ import { sliceNum } from "../../common/numToAutoFixed";
 export const androidSize = (
   node: SceneNode,
   optimizeLayout: boolean
-): { width: string; height: string } => {
+): { width: string; height: string; weight: boolean } => {
   const size = nodeSize(node, optimizeLayout);
+  let propWeight = false
 
-  // this cast will always be true, since nodeWidthHeight was called with false to relative.
+  const childHasHorizontalWeight = "children" in node 
+  && node.children.filter(child =>
+     "layoutSizingHorizontal" in child 
+     && child.layoutSizingHorizontal 
+     === "FILL").length !== 0
+
+  const childHasVerticallWeight = "children" in node 
+  && node.children.filter(child =>
+    "layoutSizingVertical" in child 
+    && child.layoutSizingVertical 
+    === "FILL").length !== 0
+
   let propWidth = "";
-  if (!size.width || ("layoutSizingHorizontal" in node && node.layoutSizingHorizontal === "HUG")) {
-    propWidth = 'wrap_content';
-  } else if (size.width === "fill" || ("layoutSizingHorizontal" in node && node.layoutSizingHorizontal === "FILL")) {
+  if("layoutSizingHorizontal" in node && node.layoutSizingHorizontal === "FILL") {
+    propWeight = true;
     propWidth = 'match_parent';
-  } else if (typeof size.width === "number") {
+  } else if (childHasHorizontalWeight) {
+    propWidth = `${node.width}dp`;
+  } else if (!size.width || ("layoutSizingHorizontal" in node && node.layoutSizingHorizontal === "HUG")) {
+    propWidth = 'wrap_content';
+  } else if (size.width === "fill") {
+    propWidth = 'match_parent';
+  } else {
     propWidth = `${size.width}dp`;
   }
 
   let propHeight = "";
-  if (!size.height || ("layoutSizingVertical" in node && node.layoutSizingVertical === "HUG")) {
-    propHeight = 'wrap_content';
-  } else if (size.height === "fill" || ("layoutSizingVertical" in node && node.layoutSizingVertical === "FILL")) {
+  if ("layoutSizingVertical" in node && node.layoutSizingVertical === "FILL") {
+    propWeight = true
     propHeight = 'match_parent';
-  } else if (typeof size.height === "number") {
+  } else if (childHasVerticallWeight) {
+    propWidth = `${node.width}dp`;
+  } else if (!size.height || ("layoutSizingVertical" in node && node.layoutSizingVertical === "HUG")) {
+    propHeight = 'wrap_content';
+  } else if (size.height === "fill") {
+    propHeight = 'match_parent';
+  } else {
     propHeight = `${size.height}dp`;
   }
 
-  return { width: propWidth, height: propHeight };
+  return { width: propWidth, height: propHeight , weight: propWeight};
 };


### PR DESCRIPTION
### Fixed
- Fixed to identify LinearLayout when Frame has LinearLayoutNameID like "linear" or "lin"
### Added
- Added android: layout_weight when using Figma "Fill" in LinearComponent.
- Made "vLinear" and "hLinear" usable again.