### PR TITLE
出力するXMLのバグ修正

### DIFF
--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -60,7 +60,7 @@ export function resourceName(name: string): string {
   return snakeCaseWords.join("_");
 }
 
-export function resourceFontName(name: string): string {
+export function resourceLowerCaseName(name: string): string {
   const words = name.toLocaleLowerCase().split(/[^a-zA-Z0-9]+/);
   const snakeCaseWords = words.map((word, index) => {
     if (index === 0) {
@@ -217,7 +217,7 @@ export class androidDefaultBuilder {
     const segments = globalTextStyleSegments[node.id];
     if (segments) {
       const segment = segments[0];
-      const font = resourceFontName(segment.fontName.family)
+      const font = resourceLowerCaseName(segment.fontName.family)
       const textSize = segment.fontSize
 
       this.element.addModifier([isPlaceholder ? 'android:hint' : 'android:text', `@string/${node.name}`])

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -95,6 +95,7 @@ const androidWidgetGenerator = (
       case "COMPONENT_SET":
         if (androidNameParser(node.name).type === AndroidType.linearLayout) {
           comp.push(androidComponent(node, indentLevel))
+          break;
         }
         comp.push(androidFrame(node, indentLevel));
         break;
@@ -233,6 +234,9 @@ const androidButton = (node: SceneNode & BaseFrameMixin, setFrameLayout: boolean
   if (hasPadding && !setFrameLayout) {
     const stack = createDirectionalStack(androidButton(node, true), node.name, node, true)
     return androidContainer(node, stack)
+  } else if (setFrameLayout) {
+    result.element.addModifier(["android:clickable", "false"]);
+    result.element.addModifier(["android:focusable", "false"]);
   } else if (!hasPadding) {
     result.setId(node)
   }
@@ -507,6 +511,7 @@ const createDirectionalStack = (
 
     if (isClickable) {
       prop["android:clickable"] = "true"
+      prop["android:focusable"] = "true"
     }
 
     if ("fills" in node || androidCornerRadius(node)) {

--- a/packages/backend/src/android/androidTextBuilder.ts
+++ b/packages/backend/src/android/androidTextBuilder.ts
@@ -3,7 +3,7 @@ import {
   commonLetterSpacing,
   commonLineHeight,
 } from "../common/commonTextHeightSpacing";
-import { androidDefaultBuilder, resourceFontName } from "./androidDefaultBuilder";
+import { androidDefaultBuilder, resourceLowerCaseName } from "./androidDefaultBuilder";
 import { androidSize } from "./builderImpl/androidSize";
 import { globalTextStyleSegments } from "../altNodes/altConversion";
 import { androidElement } from "./builderImpl/androidParser";

--- a/packages/backend/src/android/builderImpl/androidColor.ts
+++ b/packages/backend/src/android/builderImpl/androidColor.ts
@@ -1,6 +1,7 @@
 import { retrieveTopFill } from "../../common/retrieveFill";
 import { getCommonRadius } from "../../common/commonRadius";
 import { sliceNum } from "../../common/numToAutoFixed";
+import { resourceLowerCaseName } from "../androidDefaultBuilder";
 
 export const AndroidSolidColor = (fill: Paint): string => {
   if (fill && fill.type === "SOLID") {
@@ -60,17 +61,16 @@ const androidFills = (node: SceneNode, isFirst: boolean): string => {
     if (fill) {
       switch(fill.type) {
         case "SOLID":
-          const solid = androidColor(fill.color, fill.opacity ?? 1.0)
+          const solid = androidColor(fill.color, fill.opacity ?? 1.0, false)
           return isFirst ? "" : "_" + solid
         case "GRADIENT_ANGULAR":
         case "GRADIENT_DIAMOND":
         case "GRADIENT_LINEAR":
         case "GRADIENT_RADIAL":
-          let gradient = ""
+          let gradient = isFirst ? `${resourceLowerCaseName(fill.type)}` : `_${resourceLowerCaseName(fill.type)}`
           let gradientColors: string[] = []
-          gradient += (isFirst ? "" : "_" + fill.type)
           fill.gradientStops.forEach((node) => {
-            const color = androidColor(node.color, node.color.a)
+            const color = androidColor(node.color, node.color.a, false)
             gradientColors.push(color)
             gradient += `_${color}`
           });
@@ -91,7 +91,7 @@ export const androidCornerRadius = (node: SceneNode): string => {
   return ""
 };
 
-export const androidColor = (color: RGB | RGBA, opacity: number): string => {
+export const androidColor = (color: RGB | RGBA, opacity: number, hasSharp: boolean = true): string => {
   if (color.r + color.g + color.b === 0 && opacity === 1) {
     return "@color/black";
   }
@@ -100,7 +100,7 @@ export const androidColor = (color: RGB | RGBA, opacity: number): string => {
     return "@color/white";
   }
 
-  return `#${color2hex(opacity)}${color2hex(color.r)}${color2hex(color.g)}${color2hex(color.b)}`;
+  return `${hasSharp ? "#" : ""}${color2hex(opacity)}${color2hex(color.r)}${color2hex(color.g)}${color2hex(color.b)}`;
 };
 
 export const color2hex = (color: number): string => {


### PR DESCRIPTION
### Fixed
- ボタンのタップ領域が異なる場合にclickableとfocusableをfalseに設定
  - タップ領域が異なるボタンでFrameLayoutをボタンとして扱うため
- breakを追加してandroidFrameに処理が走らないように修正
  - 不要なAndroidFrameの処理が走っていたため
- resourceFontNameの名前を変更し、グラデーション種類を小文字で表示するように修正
- androidColorで#を着脱できるように修正
  - android:backgroundで#が使用できないため
