### PR TITLE
テキストの横にアイコンを置くタイプのボタンを追加、テキストと背景画像を同時に使えるように修正

### DIFF
--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -227,6 +227,10 @@ const androidImage = (node: RectangleNode | VectorNode): string => {
 
 const androidButton = (node: SceneNode & BaseFrameMixin): string => {
   const buttonNode = androidButtonType(node)
+
+  if (buttonNode.type === ButtonType.IconTextButton) {
+    return androidIconTextButton(node, buttonNode.layout, buttonNode.text)
+  }
   
   const result = new androidDefaultBuilder(buttonNode.value)
     .position(node, localSettings.optimizeLayout)
@@ -238,7 +242,7 @@ const androidButton = (node: SceneNode & BaseFrameMixin): string => {
       result.element.addModifier(["android:src", `@drawable/${buttonNode.layout?.name}`]);
       result.element.addModifier(["android:background", "@color/clearColor"]);
       break;
-    case ButtonType.ButtonText:
+    case ButtonType.ImageTextButton:
       result.element.addModifier(["android:background", `@drawable/${buttonNode.layout?.name}`]) 
       break;
     default:
@@ -251,6 +255,26 @@ const androidButton = (node: SceneNode & BaseFrameMixin): string => {
   if (buttonNode.layout) {
     result.pushModifier(androidShadow(buttonNode.layout));
   }
+  
+  return result.build(0);
+};
+
+const androidIconTextButton = (node: SceneNode & BaseFrameMixin, layout: SceneNode | undefined, text: TextNode | undefined): string => {
+  const linear = node.children.filter(child => androidNameParser(child.name).type === AndroidType.linearLayout)[0]
+  const isForwardText = "children" in linear && androidNameParser(linear.children[0].name).type === AndroidType.text
+
+  const result = new androidDefaultBuilder("androidx.appcompat.widget.AppCompatButton")
+    .position(node, localSettings.optimizeLayout)
+    .size(node, localSettings.optimizeLayout)
+    .setText(text);
+  
+  if ("layoutMode" in linear && linear.layoutMode === "HORIZONTAL") {
+    result.pushModifier([`android:drawable${isForwardText ? "Right" : "Left"}`, `@drawable/${layout?.name}`])
+  } else {
+    result.pushModifier([`android:drawable${isForwardText ? "Bottom" : "Top"}`, `@drawable/${layout?.name}`])
+  }
+
+  result.element.addModifier(["android:background", "@color/clearColor"]);
   
   return result.build(0);
 };

--- a/packages/backend/src/android/builderImpl/androidButtonType.ts
+++ b/packages/backend/src/android/builderImpl/androidButtonType.ts
@@ -3,7 +3,8 @@ import { AndroidType, androidNameParser } from "./androidNameParser"
 export enum ButtonType {
   Button,
   ImageButton,
-  ButtonText
+  ImageTextButton,
+  IconTextButton
 }
 
 export const androidButtonType = (node: SceneNode & BaseFrameMixin ): {
@@ -12,36 +13,53 @@ export const androidButtonType = (node: SceneNode & BaseFrameMixin ): {
   layout: SceneNode | undefined,
   text: TextNode | undefined
 } => {
-  const layout = node.children.filter(child =>
-  child.type == "RECTANGLE" 
-  || child.type == "GROUP" 
-  || (androidNameParser(child.name).type !== AndroidType.text 
-  && (child.type === "COMPONENT" 
-  || child.type === "INSTANCE")))[0]
+  const linear = node.children.filter(child => androidNameParser(child.name).type === AndroidType.linearLayout)
+  const layout = getLayout(node)
+  const isAsset = getIsAsset(layout)
+  const childText = getChildText(node)
 
-  const isAsset = ("isAsset" in layout 
-  && layout.isAsset) 
-  || layout.type === "GROUP" 
-  || (androidNameParser(layout.name).type !== AndroidType.text
-  && (layout.type === "COMPONENT" 
-  || layout.type === "INSTANCE"))
+  if (linear.length !== 0 && getLayout(linear[0]) && getChildText(linear[0])) {
+    const layout = getLayout(linear[0])
+    const text = getChildText(linear[0])
+    return { type: ButtonType.IconTextButton, value: "", layout: layout, text: text }
+  } else if (childText === undefined) {
+    return { type: ButtonType.ImageButton, value: "ImageButton", layout: layout, text: undefined }
+  } else if (isAsset) {
+    return { type: ButtonType.ImageTextButton, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+  } else {
+    return { type: ButtonType.Button, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+  }
+}
 
-  const hasPadding = layout.width !== node.width || layout.height !== node.height
-  
-  let childText: SceneNode & TextNode | undefined = undefined
+const getChildText = (node: SceneNode & BaseFrameMixin): TextNode | undefined => {
   if (node.children.filter(child => androidNameParser(child.name).type === AndroidType.text).length !== 0) {
-    childText = node.children.filter((child): child is SceneNode & BaseFrameMixin => 
+    return node.children.filter((child): child is SceneNode & BaseFrameMixin => 
       androidNameParser(child.name).type === AndroidType.text
     )[0].children.filter((child): child is SceneNode & BaseFrameMixin =>
       androidNameParser(child.name).type === AndroidType.frameLayout
     )[0].children.filter((child): child is SceneNode & TextNode => child.type === "TEXT")[0]
   }
+}
 
-  if (childText === undefined) {
-    return { type: ButtonType.ImageButton, value: "ImageButton", layout: layout, text: undefined }
-  } else if (isAsset) {
-    return { type: ButtonType.ButtonText, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+const getLayout = (node: SceneNode & BaseFrameMixin): SceneNode | undefined => {
+  return node.children.filter(child =>
+    child.type == "RECTANGLE" 
+    || child.type == "GROUP" 
+    || (androidNameParser(child.name).type !== AndroidType.text 
+    && (child.type === "COMPONENT" 
+    || child.type === "INSTANCE"))
+  )[0]
+}
+
+const getIsAsset = (layout: SceneNode | undefined): boolean => {
+  if (layout !== undefined) {
+    return ("isAsset" in layout 
+    && layout.isAsset) 
+    || layout.type === "GROUP" 
+    || (androidNameParser(layout.name).type !== AndroidType.text
+    && (layout.type === "COMPONENT" 
+    || layout.type === "INSTANCE"))
   } else {
-    return { type: ButtonType.Button, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+    return false
   }
 }

--- a/packages/backend/src/android/builderImpl/androidButtonType.ts
+++ b/packages/backend/src/android/builderImpl/androidButtonType.ts
@@ -1,0 +1,47 @@
+import { AndroidType, androidNameParser } from "./androidNameParser"
+
+export enum ButtonType {
+  Button,
+  ImageButton,
+  ButtonText
+}
+
+export const androidButtonType = (node: SceneNode & BaseFrameMixin ): {
+  type: ButtonType, 
+  value: string, 
+  layout: SceneNode | undefined,
+  text: TextNode | undefined
+} => {
+  const layout = node.children.filter(child =>
+  child.type == "RECTANGLE" 
+  || child.type == "GROUP" 
+  || (androidNameParser(child.name).type !== AndroidType.text 
+  && (child.type === "COMPONENT" 
+  || child.type === "INSTANCE")))[0]
+
+  const isAsset = ("isAsset" in layout 
+  && layout.isAsset) 
+  || layout.type === "GROUP" 
+  || (androidNameParser(layout.name).type !== AndroidType.text
+  && (layout.type === "COMPONENT" 
+  || layout.type === "INSTANCE"))
+
+  const hasPadding = layout.width !== node.width || layout.height !== node.height
+  
+  let childText: SceneNode & TextNode | undefined = undefined
+  if (node.children.filter(child => androidNameParser(child.name).type === AndroidType.text).length !== 0) {
+    childText = node.children.filter((child): child is SceneNode & BaseFrameMixin => 
+      androidNameParser(child.name).type === AndroidType.text
+    )[0].children.filter((child): child is SceneNode & BaseFrameMixin =>
+      androidNameParser(child.name).type === AndroidType.frameLayout
+    )[0].children.filter((child): child is SceneNode & TextNode => child.type === "TEXT")[0]
+  }
+
+  if (childText === undefined) {
+    return { type: ButtonType.ImageButton, value: "ImageButton", layout: layout, text: undefined }
+  } else if (isAsset) {
+    return { type: ButtonType.ButtonText, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+  } else {
+    return { type: ButtonType.Button, value: "androidx.appcompat.widget.AppCompatButton", layout: layout, text: childText }
+  }
+}


### PR DESCRIPTION
## Did
-  androidButtonTypeを追加 97d7c8fb148a38a334eb7bc3f2e9a1a9b651bdcb
   - ButtonをMaterialDesignからWidgetButtonに変更し、Buttonだけで画像とテキストを配置できるように修正
- テキストの横にアイコンを置くタイプのボタンを追加(android:drawableRight/Left/Top/Bottom) 7143cdac6a6ff76d7ad5c0dbd25a39058fd8327f