### PR TITLE
複数のバグを修正

### DIFF
--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -127,7 +127,7 @@ export class androidDefaultBuilder {
 
   position(node: SceneNode & BaseFrameMixin, optimizeLayout: boolean): this {
     const { x, y } = getCommonPositionValue(node);
-    if (androidNameParser(node.parent?.name).type !== AndroidType.linearLayout) {
+    if (node.parent && androidNameParser(node.parent?.name).type !== AndroidType.linearLayout) {
       this.pushModifier(['android:layout_marginStart',`${sliceNum(x)}dp`]);
       this.pushModifier(['android:layout_marginTop',`${sliceNum(y)}dp`]);
     } else {

--- a/packages/backend/src/android/androidDefaultBuilder.ts
+++ b/packages/backend/src/android/androidDefaultBuilder.ts
@@ -138,10 +138,10 @@ export class androidDefaultBuilder {
         this.pushModifier(["android:layout_marginBottom",`${node.paddingBottom}dp`]);
       }
       if (node.paddingRight > 0) {
-        this.pushModifier(["android:layout_marginRight",`${node.paddingRight}dp`]);
+        this.pushModifier(["android:layout_marginEnd",`${node.paddingRight}dp`]);
       }
       if (node.paddingLeft > 0) {
-        this.pushModifier(["android:layout_marginLeft",`${node.paddingLeft}dp`]);
+        this.pushModifier(["android:layout_marginStart",`${node.paddingLeft}dp`]);
       }
     }
 

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -486,8 +486,8 @@ const createDirectionalStack = (
     const layoutPosition = `android:${hasLinearLayoutParent ? "layout_margin" : "padding"}`
 
     let prop:Record<string, string | number> = {
-      "android:layout_width": `${node.parent ? width : "match_parent"}`,
-      "android:layout_height": `${node.parent ? height : "match_parent"}`
+      "android:layout_width": `${width}`,
+      "android:layout_height": `${height}`
     }
 
     if (weight) {

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -524,10 +524,10 @@ const createDirectionalStack = (
       prop[`${layoutPosition}Bottom`] = `${node.paddingBottom}dp`
     }
     if (node.paddingRight > 0) {
-      prop[`${layoutPosition}Right`] = `${node.paddingRight}dp`
+      prop[`${layoutPosition}End`] = `${node.paddingRight}dp`
     }
     if (node.paddingLeft > 0) {
-      prop[`${layoutPosition}Left`] = `${node.paddingLeft}dp`
+      prop[`${layoutPosition}Start`] = `${node.paddingLeft}dp`
     }
 
     if (isClickable) {

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -197,6 +197,7 @@ const androidLinearSpace = (node: SceneNode): string => {
 const androidText = (textNode: SceneNode & TextNode, node: SceneNode | null = null): string => {
   const result = new androidTextBuilder()
     .createText(textNode)
+    .textAutoSize(textNode)
     .setId(node ? node : textNode)
     .position(node ? node : textNode, localSettings.optimizeLayout)
     .size(node ? node : textNode, localSettings.optimizeLayout);

--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -1,6 +1,6 @@
 import { compactProp, indentString } from "../common/indentString";
 import { className, sliceNum } from "../common/numToAutoFixed";
-import { androidBackground, androidCornerRadius } from "./builderImpl/androidColor";
+import { androidBackground, androidCornerRadius, androidStrokes } from "./builderImpl/androidColor";
 import { androidTextBuilder } from "./androidTextBuilder";
 import { androidDefaultBuilder } from "./androidDefaultBuilder";
 import { PluginSettings } from "../code";
@@ -535,7 +535,7 @@ const createDirectionalStack = (
       prop["android:focusable"] = "true"
     }
 
-    if ("fills" in node || androidCornerRadius(node)) {
+    if ("fills" in node || androidCornerRadius(node) !== "" || androidStrokes(node, false) !== "") {
       const background = androidBackground(node)
       prop[background[0]] = background[1] ?? ""
     }

--- a/packages/backend/src/android/androidTextBuilder.ts
+++ b/packages/backend/src/android/androidTextBuilder.ts
@@ -22,7 +22,7 @@ export class androidTextBuilder extends androidDefaultBuilder {
   }
 
   textAutoSize(node: TextNode): this {
-    this.modifiers.push(this.wrapTextAutoResize(node));
+    this.pushModifier(["android:textAlignment", this.wrapTextAutoResize(node)])
     return this;
   }
 
@@ -166,59 +166,36 @@ export class androidTextBuilder extends androidDefaultBuilder {
   };
 
   wrapTextAutoResize = (node: TextNode): string => {
-    const { width, height } = androidSize(node,false);
+    const { width } = androidSize(node,false);
 
     let comp: string[] = [];
     switch (node.textAutoResize) {
-      case "WIDTH_AND_HEIGHT":
-        break;
       case "HEIGHT":
         comp.push(width);
         break;
-      case "NONE":
-      case "TRUNCATE":
-        comp.push(width, height);
+      default:
         break;
     }
 
     if (comp.length > 0) {
-      const align = this.textAlignment(node);
-      return `.frame(${comp.join(", ")}${align})`;
+      return this.textAlignment(node);
     }
 
     return "";
   };
 
-  // SwiftUI has two alignments for Text, when it is a single line and when it is multiline. This one is for single line.
   textAlignment = (node: TextNode): string => {
     let hAlign = "";
-    if (node.textAlignHorizontal === "LEFT") {
-      hAlign = "leading";
-    } else if (node.textAlignHorizontal === "RIGHT") {
-      hAlign = "trailing";
-    }
-
-    let vAlign = "";
-    if (node.textAlignVertical === "TOP") {
-      vAlign = "top";
-    } else if (node.textAlignVertical === "BOTTOM") {
-      vAlign = "bottom";
-    }
-
-    if (hAlign && !vAlign) {
-      // result should be leading or trailing
-      return `, alignment: .${hAlign}`;
-    } else if (!hAlign && vAlign) {
-      // result should be top or bottom
-      return `, alignment: .${vAlign}`;
-    } else if (hAlign && vAlign) {
-      // make the first char from hAlign uppercase
-      const hAlignUpper = hAlign.charAt(0).toUpperCase() + hAlign.slice(1);
-      // result should be topLeading, topTrailing, bottomLeading or bottomTrailing
-      return `, alignment: .${vAlign}${hAlignUpper}`;
+    switch (node.textAlignHorizontal) {
+      case "LEFT":
+        hAlign = "textStart"
+      case "RIGHT":
+        hAlign = "textEnd"
+      default:
+        hAlign = "center"
     }
 
     // when they are centered
-    return "";
+    return hAlign;
   };
 }

--- a/packages/backend/src/android/builderImpl/androidColor.ts
+++ b/packages/backend/src/android/builderImpl/androidColor.ts
@@ -35,17 +35,17 @@ export const androidSolidColor = (
 };
 
 export const androidBackground = (node: SceneNode): [string, string] => {
-  const background: [string, string] = ["android:background", ""]
-  const underScore = background[1] === "" ? "" : "_"
+  const prefix = "@drawable/"
+  const background: [string, string] = ["android:background", prefix]
 
   background[1] += androidCornerRadius(node)
-  background[1] += androidFills(node, background[1] === "")
-  background[1] += androidStrokes(node, background[1] === "")
+  background[1] += androidFills(node, background[1] === prefix)
+  background[1] += androidStrokes(node, background[1] === prefix)
 
   return background
 }
 
-const androidStrokes = (node: SceneNode, isFirst: boolean): string => {
+export const androidStrokes = (node: SceneNode, isFirst: boolean): string => {
   if ("strokes" in node && node.strokes[0]) {
     const color = AndroidSolidColor(node.strokes[0])
     const lineWeight = typeof node.strokeWeight === "number" ? node.strokeWeight : 1

--- a/packages/backend/src/android/builderImpl/androidNameParser.ts
+++ b/packages/backend/src/android/builderImpl/androidNameParser.ts
@@ -70,6 +70,7 @@ export const androidNameParser = (name: string | undefined): { type: AndroidType
       case "lin":
       case "vLinear":
       case "hLinear":
+      case "Linear":
         type = AndroidType.linearLayout
         break
       default:


### PR DESCRIPTION
##Do

- textAlignmentを設定するように修正 3bd5cfa362e6a16faf7cd9c370b16c2f2ba20fd4
- paddingとmarginのLeft_RightをそれぞれStartとEnd表示に修正 c4f0709e308b796d2bda051ee1ca6f686d88bb00
- 親Viewがない時にサイズをmatch_parentにする処理を削除 fe02c37f3dfb82acf6df79e2797f3df9f51247ae

- android:backgroundの修正 fafde92c6247b3b18f0affaeff4d5c139baae49c
  - 枠線のみがあるときもandroid:backgroundを表示するように修正
  - Prefixに@drawable/をつけるように修正
- リニアレイアウト識別文字列に"Linear"を追加 ee78f870a55bcfcc331a39e81701765c20b45c2e
- Viewの位置情報を表示する条件に「親Viewがあるとき」を追加 9fa73d1f3f5fb6517485be5979401d8ea654c4ec