### PR TITLE
ボタンの画像が2枚配置された時にsrcとbackgroundで出力する

### DIFF
--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -227,7 +227,7 @@ const androidButton = (node: SceneNode & BaseFrameMixin): string => {
   const buttonNode = androidButtonType(node)
 
   if (buttonNode.type === ButtonType.IconTextButton) {
-    return androidIconTextButton(node, buttonNode.layout, buttonNode.text)
+    return androidIconTextButton(node, buttonNode.foreground, buttonNode.text)
   }
   
   const result = new androidDefaultBuilder(buttonNode.value)
@@ -236,22 +236,26 @@ const androidButton = (node: SceneNode & BaseFrameMixin): string => {
     .setText(buttonNode.text);
 
   switch (buttonNode.type) {
+    case ButtonType.BackgroundImageButton:
+      result.element.addModifier(["android:src", `@drawable/${buttonNode.foreground?.name}`]);
+      result.element.addModifier(["android:background", `@drawable/${buttonNode.background?.name}`]);
+      break;
     case ButtonType.ImageButton:
-      result.element.addModifier(["android:src", `@drawable/${buttonNode.layout?.name}`]);
+      result.element.addModifier(["android:src", `@drawable/${buttonNode.foreground?.name}`]);
       result.element.addModifier(["android:background", "@color/clearColor"]);
       break;
     case ButtonType.ImageTextButton:
-      result.element.addModifier(["android:background", `@drawable/${buttonNode.layout?.name}`]) 
+      result.element.addModifier(["android:background", `@drawable/${buttonNode.foreground?.name}`]) 
       break;
     default:
-      if (buttonNode.layout) {
-        result.element.addModifier(androidBackground(buttonNode.layout))
+      if (buttonNode.foreground) {
+        result.element.addModifier(androidBackground(buttonNode.foreground))
       }
       break;
   }
 
-  if (buttonNode.layout) {
-    result.pushModifier(androidShadow(buttonNode.layout));
+  if (buttonNode.foreground) {
+    result.pushModifier(androidShadow(buttonNode.foreground));
   }
   
   return result.build(0);

--- a/packages/backend/src/android/builderImpl/androidButtonType.ts
+++ b/packages/backend/src/android/builderImpl/androidButtonType.ts
@@ -81,6 +81,14 @@ const getLayout = (node: SceneNode & BaseFrameMixin): { foreground: SceneNode | 
     || child.type === "INSTANCE"))
   )
 
+  layout.forEach((child, index) => {
+    if (androidNameParser(child.name).type === AndroidType.view) {
+      let id = androidNameParser(child.name).id.split("_")
+      id.shift()
+      layout[index].name = id.join("_") ?? child.name
+    }
+  });
+
   switch(layout.length) {
     case 1:
       return { foreground: layout[0], backgorund: undefined }


### PR DESCRIPTION
## Do

- ボタンの画像が2枚配置された時にsrcとbackgroundで出力するように修正 0a16821eb604a6cf0b96a57c1b0c3f96c1210f73
- UIkit_btnの中にUIkit_viewがある場合、画像として認識するように修正 e9eb829230a57a26dfd59741703f533d72a8c78f

## Usage
- ボタンコンポーネントの中に画像を2枚配置する