### PR TITLE
LinearLayoutが2回出力される不具合を修正, includeFontPaddingを修正

### DIFF
--- a/packages/backend/src/android/androidMain.ts
+++ b/packages/backend/src/android/androidMain.ts
@@ -130,9 +130,6 @@ const androidWidgetGenerator = (
         comp.push(androidContainer(node));
         break;
       case "FRAME":
-        if (hasParentOfComponentSet ? parentType : type === AndroidType.linearLayout) {
-          comp.push(androidComponent(node, indentLevel));
-        }
         if (node.name === "UIkit_Color") {
           comp.push(androidColorTable(node))
         }
@@ -141,7 +138,7 @@ const androidWidgetGenerator = (
         }
         break;
       case "COMPONENT_SET":
-        comp.push(androidLinear(node, indentLevel));
+        comp.push(androidFrame(node, indentLevel));
         break;
       case "TEXT":
         comp.push(androidText(node));
@@ -427,16 +424,6 @@ const androidCheckBox = (node: SceneNode & BaseFrameMixin): string => {
   return result.build(0);
 };
 
-const androidLinear = (node: SceneNode & BaseFrameMixin, indentLevel: number): string => {
-  const children = widgetGeneratorWithLimits(
-    node,
-    node.children.length > 1 ? indentLevel + 1 : indentLevel
-  );
-
-  const anyStack = createDirectionalStack(children, node.name, node);
-  return androidContainer(node, anyStack);
-}
-
 const androidScroll = (node: SceneNode & BaseFrameMixin, indentLevel: number): string => {
 
   const children = widgetGeneratorWithLimits(
@@ -509,8 +496,6 @@ const androidComponent = (node: SceneNode & BaseFrameMixin & TextNode, indentLev
       return androidRadioButton(node)
     case AndroidType.editText:
       return androidEditText(node)
-    case AndroidType.linearLayout:
-      return androidLinear(node, indentLevel)
     default:
       return androidFrame(node, indentLevel)
   }

--- a/packages/backend/src/android/androidTextBuilder.ts
+++ b/packages/backend/src/android/androidTextBuilder.ts
@@ -129,12 +129,12 @@ export class androidTextBuilder extends androidDefaultBuilder {
       .addModifier(["android:textStyle",this.textDecoration(segment.textDecoration)])
       .addModifier(["android:typeface",this.textStyle(segment.fontName.style)])
       .addModifier(["android:textColor", this.textColor(segment.fills)])
-      .addModifier(["android:textAppearance", `@style/text_${segment.fontSize}_${segment.fontWeight}`]);
+      .addModifier(["android:textAppearance", `@style/text_${segment.fontSize}_${segment.fontWeight}`])
+      .addModifier(["android:includeFontPadding","false"]);
 
       // .addModifier(["android:textSize",`${fontSize}sp`])
       // .addModifier(["android:textFontWeight",fontWeight])
       // .addModifier(["android:fontFamily",`@font/${resourceFontName(fontFamily)}`])
-      // .addModifier(["android:includeFontPadding","false"])
 
       if (node.name !== "text_variable") {
         element.addModifier(["android:text", `@string/${node.name}`])


### PR DESCRIPTION
## Do
- LinearLayoutが2回出力される不具合を修正  ae439a4b125135aef03ea7b5beab3e17d478c08b
  -  androidLinearを削除してandroidFrameで統一
- includeFontPaddingがstyleからだと効いていなかったため、各TextViewにつけるように修正 1463c52e129de14f9c3b1dcd94d647b8716bd7e8